### PR TITLE
Don't add node constraint from deprecated edges

### DIFF
--- a/lib/pocky/packwerk.rb
+++ b/lib/pocky/packwerk.rb
@@ -97,7 +97,10 @@ module Pocky
           @graph.add_edges(
             @nodes[package],
             @nodes[provider_package],
-            **@deprecated_references_edge_options.merge(penwidth: edge_width(invocations.length)),
+            **@deprecated_references_edge_options.merge(
+              penwidth: edge_width(invocations.length),
+              constraint: false,
+            ),
           )
         end
       end


### PR DESCRIPTION
By setting `constraint: false` for deprecated references they will not be considered for node rank calculation (== vertical alignment of a node) and the rank calculation will thus be exclusively based on the accepted dependencies:

https://graphviz.org/doc/info/attrs.html#d:constraint